### PR TITLE
Feature/only init

### DIFF
--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -109,7 +109,6 @@ module.exports = {
   password: process.env.MONGODB_PASSWORD,
   database: process.env.MONGODB_DATABASE || 'local',
   loopSleepSeconds: process.env.MONGO_SIDECAR_SLEEP_SECONDS || 5,
-  unhealthySeconds: process.env.MONGO_SIDECAR_UNHEALTHY_SECONDS || 15,
   mongoSSLEnabled: stringToBool(process.env.MONGO_SSL_ENABLED),
   mongoSSLAllowInvalidCertificates: stringToBool(process.env.MONGO_SSL_ALLOW_INVALID_CERTIFICATES),
   mongoSSLAllowInvalidHostnames: stringToBool(process.env.MONGO_SSL_ALLOW_INVALID_HOSTNAMES),

--- a/src/lib/worker.js
+++ b/src/lib/worker.js
@@ -8,7 +8,6 @@ var dns = require('dns');
 var os = require('os');
 
 var loopSleepSeconds = config.loopSleepSeconds;
-var unhealthySeconds = config.unhealthySeconds;
 
 var hostIp = false;
 var hostIpAndPort = false;

--- a/src/lib/worker.js
+++ b/src/lib/worker.js
@@ -109,9 +109,7 @@ var inReplicaSet = function(db, pods, status, done) {
   //If we're already in a rs and NO ONE is a primary, elect someone to do the work for a primary
   var members = status.members;
 
-  for (var i in members) {
-    var member = members[i];
-
+  for (var member of members) {
     if (member.state === 1 && member.self) {
       return primaryWork(db, pods, members, false, done);
     }
@@ -145,9 +143,7 @@ var notInReplicaSet = function(db, pods, done) {
   //If we're not in a rs and others ARE in the rs, just continue, another path will ensure we will get added
   //If we're not in a rs and no one else is in a rs, elect one to kick things off
   var testRequests = [];
-  for (var i in pods) {
-    var pod = pods[i];
-
+  for (var pod of pods) {
     if (pod.status.phase === 'Running') {
       testRequests.push(createTestRequest(pod));
     }
@@ -158,8 +154,8 @@ var notInReplicaSet = function(db, pods, done) {
       return done(err);
     }
 
-    for (var i in results) {
-      if (results[i]) {
+    for (var result of results) {
+      if (result) {
         return done(); //There's one in a rs, nothing to do
       }
     }
@@ -218,8 +214,7 @@ var podElection = function(pods) {
 
 var addrToAddLoop = function(pods, members) {
   var addrToAdd = [];
-  for (var i in pods) {
-    var pod = pods[i];
+  for (var pod of pods) {
     if (pod.status.phase !== 'Running' || pod.status.reason === 'NodeLost') {
       continue;
     }
@@ -228,8 +223,7 @@ var addrToAddLoop = function(pods, members) {
     var podStableNetworkAddr = getPodStableNetworkAddressAndPort(pod);
     var podInRs = false;
 
-    for (var j in members) {
-      var member = members[j];
+    for (var member of members) {
       if (member.name === podIpAddr || member.name === podStableNetworkAddr) {
         /* If we have the pod's ip or the stable network address already in the config, no need to read it. Checks both the pod IP and the
         * stable network ID - we don't want any duplicates - either one of the two is sufficient to consider the node present. */


### PR DESCRIPTION
## What's this PR works for

只做 rs 的初始化工作，外加初始节点的集群加入动作，去除不必要的其它逻辑；至于集群后续运行情况全然与 sidecar 无关，其运行模式和原生 mongo 集群一致，无感。

另外，初始化工作会在集群中所有 pod 起来之后再运行。

@bbbmj @liubog2008 @supereagle @zjj2wry 请 review 一下。


### 对于集群网络分区的测试

现在做的比较“手工”，在集群组建完成之后，利用 iptables 对各个节点执行网络隔离，观察集群的状态.

1. 获取每个 mongo pod 对应的 node 和 ip:

（假定只有一个 mongo 集群）
```bash
for n in `kubectl get pod -o wide | grep mongo | awk '{printf("%s:%s\n", $1, $NF)}'`; do echo ${n%%:*} ${n##*:} `kubectl get node ${n##*:} -o yaml | grep public-ip | awk '{print $NF}'`; done
```

2. 分别在 master 或者 secondary 所在的 node 节点上对另两个 node 作网络隔离

```bash
iptables -A INPUT -s 192.168.20.140 -j DROP
iptables -A INPUT -s 192.168.20.141 -j DROP
iptables -A OUTPUT -s 192.168.20.140 -j DROP
iptables -A OUTPUT -s 192.168.20.141 -j DROP
```

3. 观察集群是否完好（可通过检查 `rs.status()` 状态，两者可以通过 db.collection 中的数据确认）

4. 恢复网络
```bash
iptables -D INPUT -s 192.168.20.140 -j DROP
iptables -D INPUT -s 192.168.20.141 -j DROP
iptables -D OUTPUT -s 192.168.20.140 -j DROP
iptables -D OUTPUT -s 192.168.20.141 -j DROP
```
此时的 master/secondary 拓扑结构与隔离时期相同（除了被隔离的节点重新加入回来成为 secondary 之外）
