### PR TITLE
feat(*): add helm chart

### DIFF
--- a/manifests/infra-mongo/.helmignore
+++ b/manifests/infra-mongo/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/manifests/infra-mongo/Chart.yaml
+++ b/manifests/infra-mongo/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+appVersion: 4.0.3
+description: A helm chart for mongo
+name: infra-mongo
+type: application
+version: 4.0.3

--- a/manifests/infra-mongo/templates/_capabilities.tpl
+++ b/manifests/infra-mongo/templates/_capabilities.tpl
@@ -1,0 +1,10 @@
+{{/*
+Return the appropriate apiVersion for statefulset.
+*/}}
+{{- define "common.capabilities.statefulset.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/manifests/infra-mongo/templates/_images.tpl
+++ b/manifests/infra-mongo/templates/_images.tpl
@@ -1,0 +1,7 @@
+{{/*
+Return the proper image name
+{{ include "common.images.image" ( dict "context" $ "repository" .Values.platformConfig.imageRepositoryRelease "imageRoot" .Values.image ) }}
+*/}}
+{{- define "common.images.image" -}}
+{{- printf "%s/%s/%s:%s" .context.Values.platformConfig.imageRegistry .repository .imageRoot.name ( default .context.Chart.AppVersion .imageRoot.tag ) -}}
+{{- end -}}

--- a/manifests/infra-mongo/templates/_labels.tpl
+++ b/manifests/infra-mongo/templates/_labels.tpl
@@ -1,0 +1,17 @@
+{{/*
+Kubernetes standard labels
+*/}}
+{{- define "common.labels.standard" -}}
+helm.sh/chart: {{ include "common.names.chart" . }}
+app.kubernetes.io/name: {{ include "common.names.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Labels to use on deploy.spec.selector.matchLabels and svc.spec.selector
+*/}}
+{{- define "common.labels.matchLabels" -}}
+app.kubernetes.io/name: {{ include "common.names.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/manifests/infra-mongo/templates/_names.tpl
+++ b/manifests/infra-mongo/templates/_names.tpl
@@ -1,0 +1,35 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "common.names.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "common.names.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "common.names.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "headlessServer.name" }}
+{{- include "common.names.fullname" . }}-headless
+{{- end }}

--- a/manifests/infra-mongo/templates/_names.tpl
+++ b/manifests/infra-mongo/templates/_names.tpl
@@ -29,7 +29,3 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 {{- end -}}
 {{- end -}}
-
-{{- define "headlessServer.name" }}
-{{- include "common.names.fullname" . }}-headless
-{{- end }}

--- a/manifests/infra-mongo/templates/_tplvalues.tpl
+++ b/manifests/infra-mongo/templates/_tplvalues.tpl
@@ -1,0 +1,12 @@
+{{/*
+Renders a value that contains template.
+Usage:
+{{ include "common.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $) }}
+*/}}
+{{- define "common.tplvalues.render" -}}
+    {{- if typeIs "string" .value }}
+        {{- tpl .value .context }}
+    {{- else }}
+        {{- tpl (.value | toYaml) .context }}
+    {{- end }}
+{{- end -}}

--- a/manifests/infra-mongo/templates/pv.yaml
+++ b/manifests/infra-mongo/templates/pv.yaml
@@ -1,0 +1,27 @@
+{{- range $index, $value := tuple "kube-master-1" "kube-master-2" "kube-master-3" }}
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: infra-mongo-infra-mongo-{{ $index }}
+spec:
+  capacity:
+    storage: 100Gi
+  volumeMode: Filesystem
+  accessModes:
+  - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  claimRef:
+    namespace: {{ $.Release.Namespace | quote }}
+    name: infra-mongo-infra-mongo-{{ $index }}
+  local:
+    path: /var/lib/compass/db/mongo
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - {{ $value }}
+{{- end }}

--- a/manifests/infra-mongo/templates/pvc.yaml
+++ b/manifests/infra-mongo/templates/pvc.yaml
@@ -1,0 +1,15 @@
+{{- range tuple "0" "1" "2" }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: infra-mongo-infra-mongo-{{ . }}
+  namespace: {{ $.Release.Namespace | quote }}
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi
+  volumeName: infra-mongo-infra-mongo-{{ . }}
+{{- end }}

--- a/manifests/infra-mongo/templates/service.yaml
+++ b/manifests/infra-mongo/templates/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.serviceName }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - name: mongo
+    port: {{ .Values.serverPort }}
+    protocol: TCP
+    targetPort: {{ .Values.serverPort }}

--- a/manifests/infra-mongo/templates/service.yaml
+++ b/manifests/infra-mongo/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.serviceName }}
+  name: {{ .Values.serviceName | quote }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/manifests/infra-mongo/templates/statefulset.yaml
+++ b/manifests/infra-mongo/templates/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}
-        image: {{ include "common.images.image" (dict "context" $ "repository" .Values.platformConfig.imageRepositoryRelease "imageRoot" .Values.image) | quote }}
+        image: {{ include "common.images.image" (dict "context" $ "repository" .Values.platformConfig.imageRepositoryLibrary "imageRoot" .Values.image) | quote }}
         imagePullPolicy: {{ default "Always" .Values.platformConfig.imagePullPolicy | quote }}
         {{- if .Values.command }}
         command: {{- include "common.tplvalues.render" ( dict "value" .Values.command "context" $) | nindent 8 }}

--- a/manifests/infra-mongo/templates/statefulset.yaml
+++ b/manifests/infra-mongo/templates/statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  serviceName: {{ .Values.serviceName }}
+  serviceName: {{ .Values.serviceName | quote }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
   replicas: {{ default 1 .Values.replicaCount }}
@@ -72,7 +72,7 @@ spec:
         - name: "MONGO_PORT"
           value: {{ .Values.serverPort | quote }}
         - name: "KUBERNETES_MONGO_SERVICE_NAME"
-          value: {{ .Values.serviceName }}
+          value: {{ .Values.serviceName | quote }}
         {{- if .Values.sidecar.resources }}
         resources: {{- toYaml .Values.sidecar.resources | nindent 10 }}
         {{- end }}

--- a/manifests/infra-mongo/templates/statefulset.yaml
+++ b/manifests/infra-mongo/templates/statefulset.yaml
@@ -1,0 +1,96 @@
+apiVersion: {{ include "common.capabilities.statefulset.apiVersion" . }}
+kind: StatefulSet
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  serviceName: {{ .Values.serviceName }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+  replicas: {{ default 1 .Values.replicaCount }}
+  template:
+    metadata:
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
+        {{- if .Values.podLabels }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
+        {{- end }}
+      {{- if .Values.podAnnotations }}
+      annotations:
+        {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: {{ include "common.images.image" (dict "context" $ "repository" .Values.platformConfig.imageRepositoryRelease "imageRoot" .Values.image) | quote }}
+        imagePullPolicy: {{ default "Always" .Values.platformConfig.imagePullPolicy | quote }}
+        {{- if .Values.command }}
+        command: {{- include "common.tplvalues.render" ( dict "value" .Values.command "context" $) | nindent 8 }}
+        {{- else }}
+        command:
+        - "mongod"
+        {{- end }}
+        {{- if .Values.args }}
+        args: {{- include "common.tplvalues.render" ( dict "value" .Values.args "context" $) | nindent 8 }}
+        {{- else }}
+        args:
+        - "--replSet"
+        - "rs0"
+        - "--bind_ip"
+        - "0.0.0.0"
+        {{- end }}
+        {{- if .Values.serverPort }}
+        ports:
+        - name: mongo
+          containerPort: {{ .Values.serverPort }}
+        {{- end }}
+        {{- if .Values.resources }}
+        resources: {{- toYaml .Values.resources | nindent 10 }}
+        {{- end }}
+        {{- if .Values.persistence.enabled }}
+        volumeMounts:
+        - name: {{ include "common.names.fullname" . }}
+          mountPath: {{ .Values.persistence.mountPath | quote }}
+        {{- end }}
+      - name: {{ .Chart.Name }}-sidecar
+        image: {{ include "common.images.image" (dict "context" $ "repository" .Values.platformConfig.imageRepositoryRelease "imageRoot" .Values.sidecar.image) | quote }}
+        imagePullPolicy: {{ default "Always" .Values.platformConfig.imagePullPolicy | quote }}
+        env:
+        - name: "KUBE_NAMESPACE"
+          value: {{ .Release.Namespace | quote }}
+        - name: "MONGO_SIDECAR_POD_LABELS"
+          value: "app.kubernetes.io/name=infra-mongo"
+        - name: "MONGO_PORT"
+          value: {{ .Values.serverPort | quote }}
+        - name: "KUBERNETES_MONGO_SERVICE_NAME"
+          value: {{ .Values.serviceName }}
+        {{- if .Values.sidecar.resources }}
+        resources: {{- toYaml .Values.sidecar.resources | nindent 10 }}
+        {{- end }}
+  {{- if .Values.persistence.enabled }}
+  volumeClaimTemplates:
+  - metadata:
+      name: {{ include "common.names.fullname" . }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
+        {{- if .Values.commonLabels }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 8 }}
+        {{- end }}
+    spec:
+      accessModes:
+      {{- range .Values.persistence.accessModes }}
+        - {{ . | quote }}
+      {{- end }}
+      storageClassName: {{ .Values.persistence.storageClass | quote }}
+      resources:
+        requests:
+          storage: {{ .Values.persistence.size | quote }}
+  {{- end }}

--- a/manifests/infra-mongo/values.yaml
+++ b/manifests/infra-mongo/values.yaml
@@ -1,6 +1,7 @@
 platformConfig:
   imageRegistry: cargo.dev.caicloud.xyz
-  imageRepositoryRelease: library
+  imageRepositoryLibrary: library
+  imageRepositoryRelease: release
   imagePullPolicy: Always
 
 image:

--- a/manifests/infra-mongo/values.yaml
+++ b/manifests/infra-mongo/values.yaml
@@ -9,7 +9,7 @@ image:
   # tag:
 
 serverPort: 27017
-# priorityClassName: platform-system-critical
+priorityClassName: system-cluster-critical
 replicaCount: 3
 serviceName: mgo-cluster
 

--- a/manifests/infra-mongo/values.yaml
+++ b/manifests/infra-mongo/values.yaml
@@ -1,0 +1,73 @@
+platformConfig:
+  imageRegistry: cargo.dev.caicloud.xyz
+  imageRepositoryRelease: library
+  imagePullPolicy: Always
+
+image:
+  name: mongo
+  # tag:
+
+serverPort: 27017
+# priorityClassName: platform-system-critical
+replicaCount: 3
+serviceName: mgo-cluster
+
+persistence:
+  enabled: true
+  storageClass:
+  accessModes:
+  - ReadWriteOnce
+  size: 50Gi
+  mountPath: /data/db
+
+resources:
+  limits:
+    memory: 5Gi
+    cpu: 500m
+  requests:
+    memory: 2Gi
+    cpu: 100m
+
+sidecar:
+  image:
+    name: mongo-k8s-sidecar
+    tag: v0.0.9
+  resources:
+    requests:
+      cpu: 20m
+      memory: 100Mi
+    limits:
+      cpu: 50m
+      memory: 200Mi
+
+## String to partially override aspnet-core.fullname template (will maintain the release name)
+##
+# nameOverride:
+
+## String to fully override aspnet-core.fullname template
+##
+# fullnameOverride:
+
+## Command and args for running the container (set to default if not set). Use array form
+##
+# command: []
+# args: []
+
+## Add labels to all the deployed resources
+##
+# commonLabels: {}
+
+## Add annotations to all the deployed resources
+##
+# commonAnnotations: {}
+
+## Pod labels
+## Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+##
+# podLabels: {}
+
+## Pod annotations
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+##
+# podAnnotations: {}
+


### PR DESCRIPTION
增加新版本 mongo 的 helm chart，渲染结果如下：

```yaml
---
# Source: infra-mongo/templates/pv.yaml
apiVersion: v1
kind: PersistentVolume
metadata:
  name: infra-mongo-infra-mongo-0
spec:
  capacity:
    storage: 100Gi
  volumeMode: Filesystem
  accessModes:
  - ReadWriteOnce
  persistentVolumeReclaimPolicy: Retain
  claimRef:
    namespace: "default"
    name: infra-mongo-infra-mongo-0
  local:
    path: /var/lib/compass/db/mongo
  nodeAffinity:
    required:
      nodeSelectorTerms:
      - matchExpressions:
        - key: kubernetes.io/hostname
          operator: In
          values:
          - kube-master-1
---
# Source: infra-mongo/templates/pv.yaml
apiVersion: v1
kind: PersistentVolume
metadata:
  name: infra-mongo-infra-mongo-1
spec:
  capacity:
    storage: 100Gi
  volumeMode: Filesystem
  accessModes:
  - ReadWriteOnce
  persistentVolumeReclaimPolicy: Retain
  claimRef:
    namespace: "default"
    name: infra-mongo-infra-mongo-1
  local:
    path: /var/lib/compass/db/mongo
  nodeAffinity:
    required:
      nodeSelectorTerms:
      - matchExpressions:
        - key: kubernetes.io/hostname
          operator: In
          values:
          - kube-master-2
---
# Source: infra-mongo/templates/pv.yaml
apiVersion: v1
kind: PersistentVolume
metadata:
  name: infra-mongo-infra-mongo-2
spec:
  capacity:
    storage: 100Gi
  volumeMode: Filesystem
  accessModes:
  - ReadWriteOnce
  persistentVolumeReclaimPolicy: Retain
  claimRef:
    namespace: "default"
    name: infra-mongo-infra-mongo-2
  local:
    path: /var/lib/compass/db/mongo
  nodeAffinity:
    required:
      nodeSelectorTerms:
      - matchExpressions:
        - key: kubernetes.io/hostname
          operator: In
          values:
          - kube-master-3
---
# Source: infra-mongo/templates/pvc.yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: infra-mongo-infra-mongo-0
  namespace: "default"
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 100Gi
  volumeName: infra-mongo-infra-mongo-0
---
# Source: infra-mongo/templates/pvc.yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: infra-mongo-infra-mongo-1
  namespace: "default"
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 100Gi
  volumeName: infra-mongo-infra-mongo-1
---
# Source: infra-mongo/templates/pvc.yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: infra-mongo-infra-mongo-2
  namespace: "default"
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 100Gi
  volumeName: infra-mongo-infra-mongo-2
---
# Source: infra-mongo/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: mgo-cluster
  namespace: "default"
  labels:
    helm.sh/chart: infra-mongo-4.0.3
    app.kubernetes.io/name: infra-mongo
    app.kubernetes.io/instance: infra-mongo
    app.kubernetes.io/managed-by: Helm
spec:
  selector:
    app.kubernetes.io/name: infra-mongo
    app.kubernetes.io/instance: infra-mongo
  type: ClusterIP
  clusterIP: None
  ports:
  - name: mongo
    port: 27017
    protocol: TCP
    targetPort: 27017
---
# Source: infra-mongo/templates/statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: infra-mongo
  namespace: "default"
  labels:
    helm.sh/chart: infra-mongo-4.0.3
    app.kubernetes.io/name: infra-mongo
    app.kubernetes.io/instance: infra-mongo
    app.kubernetes.io/managed-by: Helm
spec:
  serviceName: mgo-cluster
  selector:
    matchLabels:
      app.kubernetes.io/name: infra-mongo
      app.kubernetes.io/instance: infra-mongo
  replicas: 3
  template:
    metadata:
      labels:
        helm.sh/chart: infra-mongo-4.0.3
        app.kubernetes.io/name: infra-mongo
        app.kubernetes.io/instance: infra-mongo
        app.kubernetes.io/managed-by: Helm
    spec:
      containers:
      - name: infra-mongo
        image: "cargo.dev.caicloud.xyz/library/mongo:4.0.3"
        imagePullPolicy: "Always"
        command:
        - "mongod"
        args:
        - "--replSet"
        - "rs0"
        - "--bind_ip"
        - "0.0.0.0"
        ports:
        - name: mongo
          containerPort: 27017
        resources:
          limits:
            cpu: 500m
            memory: 5Gi
          requests:
            cpu: 100m
            memory: 2Gi
        volumeMounts:
        - name: infra-mongo
          mountPath: "/data/db"
      - name: infra-mongo-sidecar
        image: "cargo.dev.caicloud.xyz/release/mongo-k8s-sidecar:v0.0.9"
        imagePullPolicy: "Always"
        env:
        - name: "KUBE_NAMESPACE"
          value: "default"
        - name: "MONGO_SIDECAR_POD_LABELS"
          value: "app.kubernetes.io/name=infra-mongo"
        - name: "MONGO_PORT"
          value: "27017"
        - name: "KUBERNETES_MONGO_SERVICE_NAME"
          value: mgo-cluster
        resources:
          limits:
            cpu: 50m
            memory: 200Mi
          requests:
            cpu: 20m
            memory: 100Mi
  volumeClaimTemplates:
  - metadata:
      name: infra-mongo
      labels:
        helm.sh/chart: infra-mongo-4.0.3
        app.kubernetes.io/name: infra-mongo
        app.kubernetes.io/instance: infra-mongo
        app.kubernetes.io/managed-by: Helm
    spec:
      accessModes:
        - "ReadWriteOnce"
      storageClassName:
      resources:
        requests:
          storage: "50Gi"
```

注意事项：

* mongo-bak 后面版本再上
* 目前 PV 中的节点名是写死的，后面会改成通过由 release 传递值的方式

/cc @qianlei90 @xpofei @bbbmj 